### PR TITLE
fix a compilation failure on Mac OS 10.8.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.4)
 project(zindex)
 
 if (APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++ -Wall -Werror -Wextra")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -Wall -Werror -Wextra")
 endif()


### PR DESCRIPTION
    $ clang++ --version
    Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)

Error was in:

    zindex/src/File.h:14:19: error: no type named 'unique_ptr' in namespace 'std'
        using File = std::unique_ptr<FILE, impl::Closer>;

Hints from: http://stackoverflow.com/questions/11853822/clang-3-1-cant-see-unique-ptr

----

The full error trace:

```sh
$ make
mkdir -p build/Release
cd build/Release && cmake /tmp/zindex -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is AppleClang 5.1.0.5030040
-- The CXX compiler identification is AppleClang 5.1.0.5030040
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /usr/lib/libz.dylib (found version "1.2.5")
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/zindex/build/Release
make -C build/Release all
Scanning dependencies of target libzindex
[  4%] Building CXX object CMakeFiles/libzindex.dir/src/Index.cpp.o
In file included from /tmp/zindex/src/Index.cpp:1:
In file included from /tmp/zindex/src/Index.h:3:
/tmp/zindex/src/File.h:14:19: error: no type named 'unique_ptr' in namespace 'std'
using File = std::unique_ptr<FILE, impl::Closer>;
             ~~~~~^
/tmp/zindex/src/File.h:14:29: error: expected ';' after alias declaration
using File = std::unique_ptr<FILE, impl::Closer>;
                            ^
                            ;
In file included from /tmp/zindex/src/Index.cpp:1:
/tmp/zindex/src/Index.h:5:10: fatal error: 'cstdint' file not found
#include <cstdint>
         ^
3 errors generated.
make[3]: *** [CMakeFiles/libzindex.dir/src/Index.cpp.o] Error 1
make[2]: *** [CMakeFiles/libzindex.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 2
```