### PR TITLE
Fix build issues on OSX 10.12

### DIFF
--- a/src/Pipe.cpp
+++ b/src/Pipe.cpp
@@ -1,5 +1,7 @@
 #include <unistd.h>
 #include <stdexcept>
+#include <string>
+#include <errno.h>
 
 #include "Pipe.h"
 

--- a/src/RegExpIndexer.h
+++ b/src/RegExpIndexer.h
@@ -9,11 +9,11 @@
 // indices to an IndexSink.
 class RegExpIndexer : public LineIndexer {
     RegExp re_;
-    uint captureGroup_;
+    unsigned int captureGroup_;
 
 public:
     explicit RegExpIndexer(const std::string &regex);
-    explicit RegExpIndexer(const std::string &regex, uint captureGroup);
+    explicit RegExpIndexer(const std::string &regex, unsigned int captureGroup);
     void index(IndexSink &sink, StringView line) override;
 
 private:


### PR DESCRIPTION
I ran into some issues building on OSX 10.12 with AppleClang 9.0.0.9000039, which this PR addresses.

```
/Users/sfell/code/zindex/src/Pipe.cpp:10:41: error: no member named 'to_string' in namespace 'std'
                                 + std::to_string(errno)); // TODO: errno
                                   ~~~~~^
/Users/sfell/code/zindex/src/Pipe.cpp:10:51: error: use of undeclared identifier 'errno'
                                 + std::to_string(errno)); // TODO: errno
/Users/sfell/code/zindex/src/RegExpIndexer.h:12:5: error: unknown type name 'uint'; did you mean 'int'?
    uint captureGroup_;
    ^~~~
    int

```

