### PR TITLE
Don't save all lineoffsets if sparseLineOffsets is set

### DIFF
--- a/src/Index.cpp
+++ b/src/Index.cpp
@@ -462,7 +462,6 @@ struct Index::Builder::Impl : LineSink {
     Sqlite::Statement addMetaSql;
     uint64_t indexEvery = DefaultIndexEvery;
     std::unordered_map<std::string, std::unique_ptr<IndexHandler>> indexers;
-    std::vector<uint64_t> indexedLines_;
     bool saveAllLines_;
     bool sparseLineOffsets_;
 

--- a/src/Index.cpp
+++ b/src/Index.cpp
@@ -66,6 +66,44 @@ struct Progress {
     }
 };
 
+
+struct OneLineSink : LineSink {
+    bool complete = false;
+    const size_t lineNum;
+    LineSink &delegate;
+    const char *lastLine;
+
+    OneLineSink(size_t lineNum, LineSink &delegate) : lineNum(lineNum), delegate(delegate) {}
+
+    bool onLine(
+            size_t lineNumber,
+            size_t fileOffset,
+            const char *line, size_t length) override {
+        lastLine = line;
+        if (lineNum == lineNumber) {
+            delegate.onLine(lineNumber, fileOffset, line, length);
+            complete = true;
+        }
+
+        return true;
+    }
+    
+};
+
+struct DelegatinhPrintSink : LineSink {
+    bool enabled;
+    LineSink &sink;
+    DelegatinhPrintSink(bool enabled, LineSink &sink) : enabled(enabled), sink(sink) { }
+
+    bool onLine(size_t l, size_t size, const char *line, size_t length) override {
+        if (enabled) {
+            std::cout << l << ":" << std::string(line, length) << std::endl;
+        }
+        
+        return sink.onLine(l, size, line, length);
+    }
+};
+
 size_t makeWindow(uint8_t *out, size_t outSize, const uint8_t *in,
                   uint64_t left) {
     uint8_t temp[WindowSize];
@@ -228,6 +266,7 @@ struct Index::Impl {
     File compressed_;
     Sqlite db_;
     Sqlite::Statement lineQuery_;
+    Sqlite::Statement sparseLineOffsetsQuery_;
     Index::Metadata metadata_;
     size_t blockSize_;
     std::unique_ptr<CachedContext> cachedContext_;
@@ -237,10 +276,14 @@ struct Index::Impl {
             : log_(log), compressed_(std::move(fromCompressed)),
               db_(std::move(db)),
               lineQuery_(db_.prepare(R"(
-SELECT line, offset, compressedOffset, uncompressedOffset, length, bitOffset, window
-FROM LineOffsets, AccessPoints
-WHERE offset >= uncompressedOffset AND offset <= uncompressedEndOffset
-AND line = :line
+SELECT lo.line, lo.offset, ap.compressedOffset, ap.uncompressedOffset, lo.length, ap.bitOffset, ap.window, ap.lineNum
+FROM LineOffsets lo, AccessPoints ap
+WHERE lo.offset >= ap.uncompressedOffset AND offset <= ap.uncompressedEndOffset
+AND lo.line = :line
+LIMIT 1)")), 
+            sparseLineOffsetsQuery_(db_.prepare(R"(
+SELECT lineNum, compressedOffset, uncompressedOffset, bitOffset, window
+FROM AccessPoints where lineNum <= :line order by lineNum desc
 LIMIT 1)")) {
         try {
             auto queryMeta = db_.prepare("SELECT key, value FROM Metadata");
@@ -255,7 +298,9 @@ LIMIT 1)")) {
         } catch (const std::exception &e) {
             log.warn("Caught exception reading metadata: ", e.what());
         }
+        
         sparseLineOffsets_ = metadata_.find("sparseLineOffsets") != metadata_.end() && metadata_.at("sparseLineOffsets") == "1";
+    
         auto stmt = db_.prepare(
                 "SELECT MAX(uncompressedEndOffset)/COUNT(*) FROM AccessPoints");
         if (stmt.step()) {
@@ -303,7 +348,26 @@ LIMIT 1)")) {
     bool getLine(uint64_t line, LineSink &sink) {
         lineQuery_.reset();
         lineQuery_.bindInt64(":line", line);
-        if (lineQuery_.step()) return false;
+        auto noResults = lineQuery_.step();
+        if (noResults) {
+            if (sparseLineOffsets_) {
+                
+                sparseLineOffsetsQuery_.reset();
+                sparseLineOffsetsQuery_.bindInt64(":line", line);
+                if (sparseLineOffsetsQuery_.step()) {
+                    return false;
+                }                
+                auto lineNum = static_cast<size_t>(sparseLineOffsetsQuery_.columnInt64(0));
+                auto compressedOffset = static_cast<size_t>(sparseLineOffsetsQuery_.columnInt64(1));
+                auto uncompressedOffset = static_cast<size_t>(sparseLineOffsetsQuery_.columnInt64(2));
+                auto bitOffset = static_cast<int>(sparseLineOffsetsQuery_.columnInt64(3));
+                auto windowData = sparseLineOffsetsQuery_.columnBlob(4);
+                print(lineNum, line, 0, compressedOffset, uncompressedOffset, bitOffset, 0, windowData, sink);
+            }
+            return false;
+        }
+        
+
         print(lineQuery_, sink);
         return true;
     }
@@ -338,7 +402,7 @@ WHERE key = :query
         return tableSize("index_" + index);
     }
 
-     size_t tableSize(const std::string &name) const {
+    size_t tableSize(const std::string &name) const {
         auto stmt = db_.prepare("SELECT COUNT(*) FROM " + name);
         if (stmt.step()) return 0;
         return static_cast<size_t>(stmt.columnInt64(0));
@@ -347,23 +411,26 @@ WHERE key = :query
     void print(Sqlite::Statement &q, LineSink &sink) {
         auto line = static_cast<size_t>(q.columnInt64(0));
         auto offset = static_cast<size_t>(q.columnInt64(1));
-        // We use and update context while in here. Only if we successfully
-        // decode a line do we save it in the cachedContext_ for a subsequent
-        // call.
+        auto compressedOffset = static_cast<size_t>(q.columnInt64(2));
+        auto uncompressedOffset = static_cast<size_t>(q.columnInt64(3));
+        auto bitOffset = static_cast<int>(q.columnInt64(5));
+        auto length = q.columnInt64(4);
+        auto windowData = q.columnBlob(6);
+        print(0, line, offset, compressedOffset, uncompressedOffset, bitOffset, length, windowData, sink);
+    }
+
+    std::unique_ptr<CachedContext> resetContext(size_t offset, size_t compressedOffset, size_t uncompressedOffset, int bitOffset, const std::vector<uint8_t> windowData) {
         std::unique_ptr<CachedContext> context;
         if (cachedContext_ && cachedContext_->offsetWithinRange(offset)) {
             // We can reuse the previous context.
             log_.debug("Reusing previous context");
             context = std::move(cachedContext_);
         } else {
-            auto compressedOffset = static_cast<size_t>(q.columnInt64(2));
-            auto uncompressedOffset = static_cast<size_t>(q.columnInt64(3));
-            auto bitOffset = static_cast<int>(q.columnInt64(5));
             log_.debug("Creating new context at offset ", compressedOffset, ":",
                        bitOffset);
             context.reset(new CachedContext(uncompressedOffset, blockSize_));
             uint8_t window[WindowSize];
-            uncompress(q.columnBlob(6), window, WindowSize);
+            uncompress(windowData, window, WindowSize);
 
             seek(compressed_, bitOffset ? compressedOffset - 1
                                         : compressedOffset);
@@ -379,16 +446,89 @@ WHERE key = :query
             X(inflateSetDictionary(&context->zs_.stream,
                                    &window[0], WindowSize));
         }
-        uint8_t discardBuffer[WindowSize];
+        return context;
+    }
 
-        auto length = q.columnInt64(4);
-        constexpr auto MaxLength = 64u * 1024 * 1024;
-        if (length >= MaxLength) throw std::runtime_error("Line too long!");
+    void print(size_t lineNum, size_t line, size_t offset, size_t compressedOffset, size_t uncompressedOffset, int bitOffset, size_t length, const std::vector<uint8_t> windowData, LineSink &sink) {
+        // We use and update context while in here. Only if we successfully
+        // decode a line do we save it in the cachedContext_ for a subsequent
+        // call.
+        constexpr auto MaxLength = (64u * 1024 * 1024) - 1;
+        std::unique_ptr<CachedContext> context = resetContext(offset != 0 ? offset : uncompressedOffset - 1, compressedOffset, uncompressedOffset, bitOffset, windowData);
+        uint8_t discardBuffer[WindowSize];        
+        auto &zs = context->zs_;
+        if (lineNum != 0) {
+            //pass the data to linefinder until we pass the desired line
+
+            OneLineSink oneLiner(line - lineNum, sink);
+            DelegatinhPrintSink delegating(false, oneLiner);
+            LineFinder finder(delegating);
+
+            bool first = true;
+            auto ret = 0;
+            uint8_t window[WindowSize];
+
+
+            do {
+                if (zs.stream.avail_in == 0) {
+                    zs.stream.avail_in = ::fread(context->input_, 1,
+                                                 sizeof(context->input_),
+                                                 compressed_.get());
+                    if (ferror(compressed_.get())) throw ZlibError(Z_ERRNO);
+                    if (zs.stream.avail_in == 0) throw ZlibError(Z_DATA_ERROR);
+                    zs.stream.next_in = context->input_;
+                }
+
+                if (zs.stream.avail_out == 0) {
+                    zs.stream.avail_out = WindowSize;
+                    zs.stream.next_out = window;
+                    if (!first) {
+                        finder.add(window, WindowSize, false);
+                    }
+                    first = false;
+                }
+                
+                auto availBefore = zs.stream.avail_out;
+                ret = inflate(&zs.stream, Z_NO_FLUSH);
+                if (ret == Z_NEED_DICT) throw ZlibError(Z_DATA_ERROR);
+                if (ret == Z_MEM_ERROR || ret == Z_DATA_ERROR)
+                    throw ZlibError(ret);
+                auto numUncompressed = availBefore - zs.stream.avail_out;
+                context->uncompressedOffset_ += numUncompressed;
+                if (ret == Z_STREAM_END) {
+                    // The end of the stream; but is it the end of the file?
+                    if (zs.stream.avail_in == 0 && feof(compressed_.get()))
+                        break; // yes: we're done
+                    // Else, we're going to restart the decompressor: gzip
+                    // allows for multiple gzip files to be concatenated
+                    // together and says they should be treated as a single
+                    // file.
+                    log_.debug("Resetting stream at EOS at offset ",
+                               context->uncompressedOffset_);
+                    // As we opened the stream in RAW mode we can't continue
+                    // decoding from here: the decoder doesn't know if there's
+                    // a trailing CRC or similar here. So we have to throw away
+                    // state at this point. We know the indexer always stops us
+                    // from crossing a divide here. We check we weren't skipping
+                    // still (which we ought not to be...) and then chuck the
+                    // whole context out.  Ideally we'd skip the (optional?)
+                    // trailer and reset the zlib state back in normal, non-raw
+                    // mode and play on.
+                    context.reset();
+                }
+            } while (ret != Z_STREAM_END);
+            finder.add(window, WindowSize - zs.stream.avail_out, true);
+
+            return;
+        }
+
+
+        if (length > MaxLength) throw std::runtime_error("Line too long!");
         std::unique_ptr<uint8_t[]> lineBuf(new uint8_t[length]);
 
         auto numToSkip = offset - context->uncompressedOffset_;
         bool skipping = true;
-        auto &zs = context->zs_;
+
         do {
             if (numToSkip == 0 && skipping) {
                 zs.stream.avail_out = static_cast<uInt>(length);
@@ -448,6 +588,7 @@ WHERE key = :query
         } while (skipping);
         // Save the context for next time.
         cachedContext_ = std::move(context);
+        log_.debug("lineNum:" + lineNum);
         sink.onLine(line, offset, reinterpret_cast<const char *>(lineBuf.get()),
                     length - 1);
     }
@@ -581,7 +722,8 @@ INSERT INTO LineOffsets VALUES(:line, :offset, :length))");
                 zs.stream.next_in = input;
             }
             do {
-                if (zs.stream.avail_out == 0) {
+                
+                if (zs.stream.avail_out == 0 ) {
                     zs.stream.avail_out = WindowSize;
                     zs.stream.next_out = window;
                     if (!first) {
@@ -589,6 +731,8 @@ INSERT INTO LineOffsets VALUES(:line, :offset, :length))");
                     }
                     first = false;
                 }
+                
+                
                 totalIn += zs.stream.avail_in;
                 totalOut += zs.stream.avail_out;
                 ret = inflate(&zs.stream, Z_BLOCK);
@@ -609,6 +753,11 @@ INSERT INTO LineOffsets VALUES(:line, :offset, :length))");
                     log.debug("Creating checkpoint at ", PrettyBytes(totalOut),
                               " (compressed offset ", PrettyBytes(totalIn),
                               ")");
+                    auto currentLineNumber = finder.lineOffsets().size();
+                    if (WindowSize != zs.stream.avail_out) {
+                        for (unsigned int i = 0; i < WindowSize - zs.stream.avail_out; i++)
+                            if (window[i] == '\n') currentLineNumber++;
+                    }
                     if (totalOut != 0) {
                         // Flush previous information.
                         addIndex
@@ -625,7 +774,7 @@ INSERT INTO LineOffsets VALUES(:line, :offset, :length))");
                             .bindInt64(":compressedOffset", totalIn)
                             .bindInt64(":bitOffset", zs.stream.data_type & 0x7)
                             .bindBlob(":window", apWindow, size)
-                            .bindInt64(":lineNum", finder.lineOffsets().size());
+                            .bindInt64(":lineNum", currentLineNumber);
                     last = totalOut;
                     emitInitialAccessPoint = false;
                 }

--- a/src/Index.h
+++ b/src/Index.h
@@ -101,6 +101,9 @@ public:
     // Return the number of entries in a particular sub-index.
     size_t indexSize(const std::string &index) const;
 
+    // Return the number of entries in a particular table.
+    size_t tableSize(const std::string &name) const;
+
     // Metadata is a blob of strings that describe aspects of the index. They're
     // pretty opaque and not designed to be used in user code.
     using Metadata = std::unordered_map<std::string, std::string>;

--- a/src/Index.h
+++ b/src/Index.h
@@ -37,14 +37,16 @@ public:
         bool unique;
         bool sparse;
         bool indexLineOffsets;
+        bool sparseLineOffsets;
 
         IndexConfig() :
-                numeric{false}, unique{false}, sparse{false}, indexLineOffsets{false} {};
+                numeric{false}, unique{false}, sparse{false}, indexLineOffsets{false}, sparseLineOffsets{false} {};
         
         IndexConfig withNumeric(bool b) { numeric = b; return *this; };
         IndexConfig withUnique(bool b) { unique = b; return *this; };
         IndexConfig withSparse(bool b) { sparse = b; return *this; };
         IndexConfig withIndexLineOffsets(bool b) { indexLineOffsets = b; return *this; };
+        IndexConfig withSparseLineOffsets(bool b) { sparseLineOffsets = b; return *this; };
     };
 
     // Retrieve a single line by line number, calling the supplied LineSink with

--- a/src/IndexParser.cpp
+++ b/src/IndexParser.cpp
@@ -41,6 +41,7 @@ void IndexParser::parseIndex(cJSON *index, Index::Builder *builder,
     config.unique = getBoolean(index, "unique");
     config.sparse = getBoolean(index, "sparse");
     config.indexLineOffsets = getBoolean(index, "indexLineOffsets");
+    config.sparseLineOffsets = getBoolean(index, "sparseLineOffsets");
 
     if (type == "regex") {
         auto regex = getOrThrowStr(index, "regex");

--- a/src/Sqlite.cpp
+++ b/src/Sqlite.cpp
@@ -147,11 +147,13 @@ void Sqlite::Statement::R(int result) const {
 }
 
 std::string Sqlite::toFile(const std::string &uri) {
+
     RegExp uriRegex("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)");
     RegExp::Matches matches;
     if (!uriRegex.exec(uri, matches)) {
         return uri;
     }
+
     auto protocol = matches[1];
     auto result = std::string(uri.c_str() + protocol.first, protocol.second - protocol.first);
     if (result.find("file:") != 0) {

--- a/src/Sqlite.cpp
+++ b/src/Sqlite.cpp
@@ -147,7 +147,9 @@ void Sqlite::Statement::R(int result) const {
 }
 
 std::string Sqlite::toFile(const std::string &uri) {
-
+    if (uri.find(":") == std::string::npos) {
+        return uri;
+    }
     RegExp uriRegex("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)");
     RegExp::Matches matches;
     if (!uriRegex.exec(uri, matches)) {

--- a/src/zindex.cpp
+++ b/src/zindex.cpp
@@ -40,6 +40,9 @@ int Main(int argc, const char *argv[]) {
                              " that have ids. Merges all rows that have no id to the most recent"
                              "id. Useful if your file is one id row followed by n data rows.",
                      cmd);
+    SwitchArg sparseLineOffsets("o", "sparseLineOffsets", "sparseLineOffsets - only save line offsets for rows"
+                             " that have ids. Useful if you do not need to query for non-indexed lines.",
+                     cmd);
     SwitchArg warnings("w", "warnings", "Log warnings at info level", cmd);
     ValueArg<uint64_t> checkpointEvery(
             "", "checkpoint-every",
@@ -106,6 +109,7 @@ int Main(int argc, const char *argv[]) {
         config.numeric = numeric.isSet();
         config.unique = unique.isSet();
         config.sparse = sparse.isSet();
+        config.sparseLineOffsets = sparseLineOffsets.isSet();
         //config.indexLineOffsets = // TODO - add command line flag if desired
 
         auto delimiter = delimiterArg.getValue();

--- a/src/zq.cpp
+++ b/src/zq.cpp
@@ -27,6 +27,7 @@ struct PrintSink : LineSink {
     }
 };
 
+
 struct PrintHandler : RangeFetcher::Handler {
     Index &index;
     LineSink &sink;

--- a/tests/IndexTest.cpp
+++ b/tests/IndexTest.cpp
@@ -168,10 +168,13 @@ TEST_CASE("indexes files", "[Index]") {
                                   testFile + ".zindex", false);
         auto indexSize = index.indexSize("default");
         CHECK(indexSize == 656);
-
         CHECK(index.indexSize("100") == 1);
 
+        auto lineOffsetsSize = index.tableSize("lineOffsets");
+        CHECK(lineOffsetsSize == 657);
+
         auto CheckLine = [&](uint64_t line, const string &expected) {
+            SCOPED_INFO(" line:"+expected);
             CaptureSink cs;
             auto l = index.getLine(line, cs);
             REQUIRE(cs.captured.size() == 1);


### PR DESCRIPTION
These changes just save space, but if the flag is passed non-indexed lines can't currently be queried.  I save the lines in the access points but wanted to break it up into smaller commits.  This feature is similar to sparse except sparse will update the offsetEnd to match the next matching line.  I will try to combine them to simplify it a bit